### PR TITLE
Use "implies" syntax to simplify asserts and avoid warning

### DIFF
--- a/verified-node-replication/src/exec/log.rs
+++ b/verified-node-replication/src/exec/log.rs
@@ -1862,7 +1862,7 @@ impl<DT: Dispatch> NrLogAppendExecDataGhost<DT> {
 
 struct_with_invariants!{
 /// keeps track of the recursive state when applying updates to the unbounded log
-tracked struct AppendEntriesGhostState<DT: Dispatch> {
+pub tracked struct AppendEntriesGhostState<DT: Dispatch> {
     pub ghost idx               : nat,
     pub ghost old_tail          : nat,
     pub tracked log_entries     : Map<nat, UnboundedLog::log<DT>>,


### PR DESCRIPTION
This helps the veritas tests ( https://github.com/verus-lang/verus/tree/main/tools/veritas ) pass with no warnings.